### PR TITLE
Export public API properly

### DIFF
--- a/dilib/__init__.py
+++ b/dilib/__init__.py
@@ -21,29 +21,3 @@ from dilib.specs import SingletonMixin as SingletonMixin
 from dilib.specs import SingletonTuple as SingletonTuple
 from dilib.specs import Spec as Spec
 from dilib.specs import SpecID as SpecID
-
-__all__ = [
-    "Config",
-    "get_config",
-    "ConfigProxy",
-    "Container",
-    "get_container",
-    "ConfigError",
-    "FrozenConfigError",
-    "InputConfigError",
-    "NewKeyConfigError",
-    "SetChildConfigError",
-    "Forward",
-    "GlobalInput",
-    "LocalInput",
-    "Object",
-    "Prototype",
-    "PrototypeMixin",
-    "Singleton",
-    "SingletonDict",
-    "SingletonList",
-    "SingletonMixin",
-    "SingletonTuple",
-    "Spec",
-    "SpecID",
-]

--- a/dilib/__init__.py
+++ b/dilib/__init__.py
@@ -1,27 +1,26 @@
-from dilib.config import Config, get_config
-from dilib.container import ConfigProxy, Container, get_container
-from dilib.errors import (
-    ConfigError,
-    FrozenConfigError,
-    InputConfigError,
-    NewKeyConfigError,
-    SetChildConfigError,
-)
-from dilib.specs import (
-    Forward,
-    GlobalInput,
-    LocalInput,
-    Object,
-    Prototype,
-    PrototypeMixin,
-    Singleton,
-    SingletonDict,
-    SingletonList,
-    SingletonMixin,
-    SingletonTuple,
-    Spec,
-    SpecID,
-)
+from dilib.config import Config as Config
+from dilib.config import get_config as get_config
+from dilib.container import ConfigProxy as ConfigProxy
+from dilib.container import Container as Container
+from dilib.container import get_container as get_container
+from dilib.errors import ConfigError as ConfigError
+from dilib.errors import FrozenConfigError as FrozenConfigError
+from dilib.errors import InputConfigError as InputConfigError
+from dilib.errors import NewKeyConfigError as NewKeyConfigError
+from dilib.errors import SetChildConfigError as SetChildConfigError
+from dilib.specs import Forward as Forward
+from dilib.specs import GlobalInput as GlobalInput
+from dilib.specs import LocalInput as LocalInput
+from dilib.specs import Object as Object
+from dilib.specs import Prototype as Prototype
+from dilib.specs import PrototypeMixin as PrototypeMixin
+from dilib.specs import Singleton as Singleton
+from dilib.specs import SingletonDict as SingletonDict
+from dilib.specs import SingletonList as SingletonList
+from dilib.specs import SingletonMixin as SingletonMixin
+from dilib.specs import SingletonTuple as SingletonTuple
+from dilib.specs import Spec as Spec
+from dilib.specs import SpecID as SpecID
 
 __all__ = [
     "Config",

--- a/dilib/__init__.py
+++ b/dilib/__init__.py
@@ -1,3 +1,4 @@
+# flake8: noqa
 from dilib.config import Config as Config
 from dilib.config import get_config as get_config
 from dilib.container import ConfigProxy as ConfigProxy

--- a/dilib/__init__.py
+++ b/dilib/__init__.py
@@ -1,4 +1,3 @@
-# flake8: noqa
 from dilib.config import Config, get_config
 from dilib.container import ConfigProxy, Container, get_container
 from dilib.errors import (
@@ -23,3 +22,29 @@ from dilib.specs import (
     Spec,
     SpecID,
 )
+
+__all__ = [
+    "Config",
+    "get_config",
+    "ConfigProxy",
+    "Container",
+    "get_container",
+    "ConfigError",
+    "FrozenConfigError",
+    "InputConfigError",
+    "NewKeyConfigError",
+    "SetChildConfigError",
+    "Forward",
+    "GlobalInput",
+    "LocalInput",
+    "Object",
+    "Prototype",
+    "PrototypeMixin",
+    "Singleton",
+    "SingletonDict",
+    "SingletonList",
+    "SingletonMixin",
+    "SingletonTuple",
+    "Spec",
+    "SpecID",
+]


### PR DESCRIPTION
* Export public API properly
  * Originally, I implemented this using `__all__`, but upon more reading, it looks like the "redundant import" is the more canonical way to export the public API.
  * https://github.com/microsoft/pyright/blob/main/docs/typed-libraries.md#library-interface
  * https://github.com/microsoft/pylance-release/issues/856#issuecomment-763793949
  * https://github.com/microsoft/pylance-release/issues/2574#issuecomment-1100806042
* Update `README` examples