### PR TITLE
Include python3.13 and fix pyright Windows issue in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,6 @@ on:
 permissions:
   contents: read
 
-
 jobs:
   # Run tests, linters, and checkers via nox
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
           - ubuntu-latest
           - macos-latest
           - windows-latest
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', 'pypy-3.8']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', 'pypy-3.8']
 
     steps:
       - name: Check out code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,7 @@ on:
 permissions:
   contents: read
 
+
 jobs:
   # Run tests, linters, and checkers via nox
   test:

--- a/noxfile.py
+++ b/noxfile.py
@@ -27,6 +27,7 @@ To do an editable install into your current env:
 
 See https://nox.thea.codes/en/stable/index.html for more.
 """
+
 import sys
 
 import nox
@@ -60,6 +61,12 @@ def mypy(session: nox.Session) -> None:
 
 @nox.session(tags=["static", "typecheck"])
 def pyright(session: nox.Session) -> None:
+    # TODO: Remove once pyright >= 1.1.387 is available. See:
+    #   - https://github.com/microsoft/pyright/issues/9296
+    #   - https://docs.python.org/3/library/sys.html#sys.platform
+    if sys.platform == "win32":
+        session.install("pyright <= 1.1.385")
+
     if is_isolated_venv(session):
         session.install("-e", ".[test]")
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,7 @@ classifiers =
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
     Topic :: Software Development :: Libraries


### PR DESCRIPTION
* Include python3.13 in CI testing
* Fix pyright Windows issue by constraining version temporarily
  * See https://github.com/microsoft/pyright/issues/9296